### PR TITLE
Add FUZZ support for subdomain enumeration

### DIFF
--- a/internal/usecase/resolve/domainreader.go
+++ b/internal/usecase/resolve/domainreader.go
@@ -67,7 +67,12 @@ func (r *DomainReader) nextSubdomain(size int) ([]byte, error) {
 	domain := r.sourceScanner.Text()
 	if r.domain != "" {
 		// Generate a subdomain from a domain and a word from the source reader
-		domain = fmt.Sprintf("%s.%s", domain, r.domain)
+		if (strings.Contains(r.domain,"FUZZ")){
+			splitDomain := strings.Split(r.domain,"FUZZ");
+			domain = fmt.Sprintf("%s%s%s",splitDomain[0], domain, splitDomain[1]);
+		} else {
+			domain = fmt.Sprintf("%s.%s", domain, r.domain);
+		}
 	}
 
 	// Sanitize the domain

--- a/internal/usecase/resolve/domainreader.go
+++ b/internal/usecase/resolve/domainreader.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-
+	"strings"
 	"github.com/d3mondev/puredns/v2/pkg/procreader"
 )
 


### PR DESCRIPTION
Adds support for the "FUZZ" placeholder when enumerating subdomains. With this change, we can specify a subdomain with the "FUZZ" keyword, and it will substitute this keyword with words in the wordlist

The code change introduces a new conditional statement that checks if the domain name contains "FUZZ". If it does, the code splits the domain name into two parts at the "FUZZ" keyword, and then generates a subdomain by inserting the word between these two parts.

This feature can be particularly useful when trying to find subdomains that follow a certain pattern, such as "admin.FUZZ.example.com", where "FUZZ" can be replaced with different words to discover different subdomains.

