### PR TITLE
fix: wildcard detection filters only subdomains of any wildcard root (and root itself)

### DIFF
--- a/pkg/wildcarder/detectiontask.go
+++ b/pkg/wildcarder/detectiontask.go
@@ -189,7 +189,7 @@ func getParent(domain string) string {
 func (t *detectionTask) domainIsWildcard(domain string, answers []AnswerHash) bool {
 	roots := t.ctx.wildcardCache.findHash(answers)
 	for _, root := range roots {
-		if strings.HasSuffix(domain, root) {
+		if domain == root || strings.HasSuffix(domain, "."+root) {
 			return true
 		}
 	}


### PR DESCRIPTION
Hello, 

This references https://github.com/d3mondev/puredns/issues/67 (the current wildcard detection filter removes any domain which has a wildcard root as suffix, which matches domains which are not subdomains of any wildcard root).

Have a good day,